### PR TITLE
Switch to checkout to head_ref on mainnet deploy

### DIFF
--- a/.github/workflows/deploy-protocol-to-miannet.yaml
+++ b/.github/workflows/deploy-protocol-to-miannet.yaml
@@ -29,7 +29,7 @@ jobs:
           submodules: recursive
           # fix for EndBug/add-and-commit
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.sha }}
+          ref: ${{ github.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
           
       - name: Setup NodeJS


### PR DESCRIPTION
🐛 fix(deploy-protocol-to-miannet.yaml): change ref to use github.head…

The ref field is changed to use `github.head_ref` instead of `github.sha`. This change is made to fix an issue with the EndBug/add-and-commit action, ensuring that the correct branch is used for deployment.